### PR TITLE
Create validate_units.py

### DIFF
--- a/tools/scripts/llm/validate_units.py
+++ b/tools/scripts/llm/validate_units.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Install needed libraries
+!pip install --quiet transformers torch sentencepiece
+
+import json
+from transformers import pipeline
+
+# Initialize the LLM once on GPU 0
+llm = pipeline(
+    "text2text-generation",
+    model="google/flan-t5-base",
+    device=0,
+    max_new_tokens=16,
+    do_sample=False
+)
+
+# Load your units.json
+with open("units.json", "r", encoding="utf-8") as f:
+    data = json.load(f)
+units = data["main"]["en"]["units"]["long"]
+
+# Flatten into "key: pattern" lines
+patterns = []
+for name, info in units.items():
+    if "unitPrefixPattern" in info:
+        patterns.append(f"{name}: {info['unitPrefixPattern']}")
+    elif "compoundUnitPattern" in info:
+        patterns.append(f"{name}: {info['compoundUnitPattern']}")
+
+# Break into 50-line chunks so we stay under the model’s context limit
+chunks = [patterns[i:i+50] for i in range(0, len(patterns), 50)]
+
+# Prompt the user (or use defaults)
+default1 = "For the following CLDR English unit patterns, reply exactly “All correct” or list any incorrect entries."
+default2 = "Which standard SI prefixes are missing? If none, reply exactly “None.”"
+default3 = "How many patterns are in this list? Reply with only the integer."
+
+instr1 = input(f"Check correctness instruction (enter to use default):\n  {default1}\n> ").strip() or default1
+instr2 = input(f"Find missing instruction (enter to use default):\n  {default2}\n> ").strip() or default2
+instr3 = input(f"Count patterns instruction (enter to use default):\n  {default3}\n> ").strip() or default3
+
+prompts = {
+    "Check correctness": instr1,
+    "Find missing": instr2,
+    "Count patterns": instr3
+}
+
+# Run each of the first two prompts across all chunks
+for label in ["Check correctness", "Find missing"]:
+    print(f"\n=== {label} ===")
+    answers = []
+    for chunk in chunks:
+        block = "\n".join(chunk)
+        prompt = f"{prompts[label]}\n\n```\n{block}\n```"
+        answers.append(llm(prompt)[0]["generated_text"].strip())
+    print(" ".join(answers))
+
+# For the count prompt, send the entire list at once
+print("\n=== Count patterns (LLM) ===")
+full_block = "\n".join(patterns)
+count_prompt = f"{prompts['Count patterns']}\n\n```\n{full_block}\n```"
+llm_count = llm(count_prompt)[0]["generated_text"].strip()
+print(llm_count)
+
+# And our ground-truth Python count
+print("\n=== Count patterns (Python) ===")
+print(len(patterns))
+


### PR DESCRIPTION
**Add interactive `validate_units.py` script for LLM-based CLDR checks**

This PR introduces a new script at `tools/scripts/llm/validate_units.py` that:

1. **Reads** the English “long” unit definitions from `units.json`.  
2. **Sends** the flattened list of unit-prefix and compound-unit patterns to an LLM (Flan-T5) for a brief analysis.  
3. **Checks** correctness with a simple “All correct” prompt, plus:
   - Detection of any missing SI prefixes  
   - Verification of the total line count (via the LLM and locally in Python)  

All three prompts can be overridden interactively—or you can just hit Enter to accept the defaults.
